### PR TITLE
Add basic profile management

### DIFF
--- a/docs/architecture/ARCHITECTURE-UserAccounts-PostUpdate-20250617.md
+++ b/docs/architecture/ARCHITECTURE-UserAccounts-PostUpdate-20250617.md
@@ -1,0 +1,24 @@
+# User Accounts & Profiles Architecture (After Update)
+
+The application now persists user profiles using localStorage and exposes a profile editing page.
+
+```mermaid
+graph TD
+    A[Next.js App]
+    B[InteractiveBoard]
+    C[Sidebar]
+    D[AuthService]
+    E[ProfileService]
+    F[Profile Page]
+    A --> B
+    A --> C
+    A --> D
+    A --> F
+    B --> D
+    D --> E
+    F --> E
+```
+
+* `ProfileService` stores `UserProfile` objects using the browser's localStorage.
+* `/profile` allows users to view and update their profile.
+* The sidebar links to the profile page.

--- a/docs/architecture/ARCHITECTURE-UserAccounts-PreUpdate-20250617.md
+++ b/docs/architecture/ARCHITECTURE-UserAccounts-PreUpdate-20250617.md
@@ -1,0 +1,19 @@
+# User Accounts & Profiles Architecture (Before Update)
+
+This document captures the relevant portions of the codebase prior to adding persistent user accounts and profile management.
+
+```mermaid
+graph TD
+    A[Next.js App]
+    B[InteractiveBoard]
+    C[Sidebar]
+    D[AuthService]
+    A --> B
+    A --> C
+    A --> D
+    B --> D
+```
+
+* Authentication is handled by `AuthService` with temporary in-memory users.
+* There is no dedicated profile storage service.
+* The UI provides a `LoginDialog` but it is not wired into the sidebar.

--- a/docs/checklists/CHECKLIST-UserAccountsProfiles-20250617.md
+++ b/docs/checklists/CHECKLIST-UserAccountsProfiles-20250617.md
@@ -1,0 +1,9 @@
+# User Accounts & Profiles Checklist (17 Jun 2025)
+
+- [ ] Implement `ProfileService` to persist user profiles in localStorage
+- [ ] Integrate `AuthService` with `ProfileService`
+- [ ] Create `/profile` page for viewing and editing the profile
+- [ ] Update `LoginForm` to use `AuthService` and create profiles
+- [ ] Add "Profile" link to the sidebar
+- [ ] Write unit tests for `ProfileService`
+- [ ] Update architecture documentation after changes

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,6 +24,7 @@ import TutorialsDialog from '@/components/TutorialsDialog';
 import ProTipsDialog from '@/components/ProTipsDialog'; // Import ProTipsDialog
 import SettingsDialog from '@/components/SettingsDialog'; // Import SettingsDialog
 import PolicyLinks from '@/components/PolicyLinks';
+import Link from 'next/link';
 
 // Lazy load the optimized board component
 const OptimizedInteractiveBoard = lazy(() => import('@/components/OptimizedInteractiveBoard'));
@@ -253,6 +254,15 @@ export default function Home() {
                         Settings
                       </span>
                     </SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <Link href="/profile" className="flex items-center gap-2" title="Profile">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-user">
+                        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                        <circle cx="12" cy="7" r="4" />
+                      </svg>
+                      Profile
+                    </Link>
                   </SidebarMenuItem>
                 </SidebarMenu>
               </SidebarGroup>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { useEffect, useState } from 'react';
+import AuthService from '@/services/AuthService';
+import ProfileService, { UserProfile } from '@/services/ProfileService';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function ProfilePage() {
+  const auth = AuthService.getInstance();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+
+  useEffect(() => {
+    const user = auth.getCurrentUser();
+    if (user) {
+      const existing = ProfileService.getProfile(user.id) || {
+        userId: user.id,
+        displayName: user.displayName || '',
+        email: user.email,
+        avatarUrl: '',
+        bio: ''
+      };
+      setProfile(existing);
+    }
+  }, []);
+
+  if (!auth.isAuthenticated()) {
+    return <p className="p-4">Please sign in first.</p>;
+  }
+
+  const save = () => {
+    if (profile) {
+      ProfileService.saveProfile(profile);
+      alert('Profile saved');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Your Profile</h1>
+      <Input
+        placeholder="Display Name"
+        value={profile?.displayName ?? ''}
+        onChange={e => setProfile(p => p ? { ...p, displayName: e.target.value } : p)}
+      />
+      <Input
+        placeholder="Avatar URL"
+        value={profile?.avatarUrl ?? ''}
+        onChange={e => setProfile(p => p ? { ...p, avatarUrl: e.target.value } : p)}
+      />
+      <Input
+        placeholder="Bio"
+        value={profile?.bio ?? ''}
+        onChange={e => setProfile(p => p ? { ...p, bio: e.target.value } : p)}
+      />
+      <Button onClick={save}>Save</Button>
+    </div>
+  );
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import AuthService from '@/services/AuthService';
+import ProfileService from '@/services/ProfileService';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -30,22 +32,21 @@ const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
     
     try {
       setLoading(true);
-      
-      // Simulate authentication delay
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // In a real app, this would call your auth service
-      // For now, just simulate a successful login
-      
-      // Play success sound
+
+      const auth = AuthService.getInstance();
+      const user = await auth.signInWithEmailPassword(email, password);
+      const profile = ProfileService.getProfile(user.id);
+      if (!profile) {
+        ProfileService.saveProfile({ userId: user.id, displayName: user.displayName || user.id, email: user.email });
+      }
+
       Feedback.success();
-      
+
       toast({
         title: 'Login successful',
         description: 'You have been logged in successfully.',
       });
-      
-      // Call the onLoginSuccess callback
+
       onLoginSuccess();
     } catch (error) {
       console.error('Login failed:', error);
@@ -66,12 +67,9 @@ const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
   const handleAnonymousLogin = async () => {
     try {
       setLoading(true);
-      
-      // Simulate authentication delay
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
-      // In a real app, this would call your auth service
-      // For now, just simulate a successful anonymous login
+
+      const auth = AuthService.getInstance();
+      await auth.signInAnonymously();
       
       // Play success sound
       Feedback.success();

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,3 +1,5 @@
+import ProfileService, { UserProfile } from './ProfileService';
+
 // User authentication states
 export enum AuthState {
   UNKNOWN = 'unknown',
@@ -45,7 +47,13 @@ class AuthService {
       // Set the current user
       this.currentUser = user;
       this.authState = AuthState.AUTHENTICATED;
-      
+
+      const profile: UserProfile = {
+        userId: user.id,
+        displayName: user.id
+      };
+      ProfileService.saveProfile(profile);
+
       return user;
     } catch (error) {
       console.error('Failed to sign in anonymously:', error);
@@ -77,7 +85,15 @@ class AuthService {
       // Set the current user
       this.currentUser = user;
       this.authState = AuthState.AUTHENTICATED;
-      
+
+      const existing = ProfileService.getProfile(userId);
+      const profile: UserProfile = existing || {
+        userId,
+        displayName: user.displayName || userId,
+        email
+      };
+      ProfileService.saveProfile(profile);
+
       return user;
     } catch (error) {
       console.error('Failed to sign in with email and password:', error);

--- a/src/services/ProfileService.ts
+++ b/src/services/ProfileService.ts
@@ -1,0 +1,31 @@
+export interface UserProfile {
+  userId: string;
+  displayName: string;
+  email?: string;
+  avatarUrl?: string;
+  bio?: string;
+}
+
+class ProfileService {
+  private static instance: ProfileService;
+
+  static getInstance(): ProfileService {
+    if (!ProfileService.instance) {
+      ProfileService.instance = new ProfileService();
+    }
+    return ProfileService.instance;
+  }
+
+  getProfile(userId: string): UserProfile | null {
+    if (typeof localStorage === 'undefined') return null;
+    const data = localStorage.getItem(`profile_${userId}`);
+    return data ? (JSON.parse(data) as UserProfile) : null;
+  }
+
+  saveProfile(profile: UserProfile): void {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(`profile_${profile.userId}` , JSON.stringify(profile));
+  }
+}
+
+export default ProfileService.getInstance();

--- a/src/services/__tests__/ProfileService.test.ts
+++ b/src/services/__tests__/ProfileService.test.ts
@@ -1,0 +1,14 @@
+import ProfileService, { UserProfile } from '../ProfileService';
+
+describe('ProfileService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('saves and retrieves profile', () => {
+    const profile: UserProfile = { userId: 'u1', displayName: 'Tester' };
+    ProfileService.saveProfile(profile);
+    const loaded = ProfileService.getProfile('u1');
+    expect(loaded).toEqual(profile);
+  });
+});


### PR DESCRIPTION
## Summary
- document current and updated architectures around user profiles
- add a session checklist for user accounts work
- implement `ProfileService` for local storage persistence
- integrate `AuthService` with `ProfileService`
- hook profile creation into login form
- add profile page and sidebar link
- test `ProfileService`

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError in lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_6851d396ffe88323b679148595fb83e5