### PR TITLE
Implement local multiplayer and redirect

### DIFF
--- a/docs/architecture/ARCHITECTURE-HostJoin-PostUpdate-20250702.md
+++ b/docs/architecture/ARCHITECTURE-HostJoin-PostUpdate-20250702.md
@@ -1,0 +1,22 @@
+# Host/Join Implementation Snapshot - After Update (02 Jul 2025)
+
+This document reflects the architecture after introducing local multiplayer functionality and improved sign‑in handling.
+
+```mermaid
+graph TD
+    A[GoogleGeminiInteractiveBoard]
+    B[LocalMultiplayer Service]
+    C[confirmHostGame]
+    D[confirmJoinGame]
+    E[ProfilePage]
+    F[AuthService]
+    A --> C
+    A --> D
+    C --> B
+    D --> B
+    E --> F
+```
+
+* `confirmHostGame` now calls `LocalMultiplayer.hostGame` and begins listening for join requests.
+* `confirmJoinGame` uses `LocalMultiplayer.joinGame` to connect with the host.
+* The profile page redirects to the home screen after a short delay when the user is not signed in.

--- a/docs/architecture/ARCHITECTURE-HostJoin-PreUpdate-20250702.md
+++ b/docs/architecture/ARCHITECTURE-HostJoin-PreUpdate-20250702.md
@@ -1,0 +1,17 @@
+# Host/Join Implementation Snapshot - Before Update (02 Jul 2025)
+
+This snapshot documents the relevant pieces of the project prior to adding real host and join game logic.
+
+```mermaid
+graph TD
+    A[GoogleGeminiInteractiveBoard]
+    B[confirmHostGame / confirmJoinGame]
+    C[Toast Notifications]
+    A --> B
+    B --> C
+    A --> D[ProfilePage]
+    D --> E[AuthService]
+```
+
+* `confirmHostGame` and `confirmJoinGame` only displayed toasts and did not establish any connection.
+* `/profile` showed **"Please sign in first."** with no navigation back when unauthenticated.

--- a/docs/checklists/CHECKLIST-HostJoinUpdate-20250702.md
+++ b/docs/checklists/CHECKLIST-HostJoinUpdate-20250702.md
@@ -1,0 +1,7 @@
+# Host/Join Update Checklist - 02 Jul 2025
+
+- [x] Document current architecture before changes.
+- [x] Create `LocalMultiplayer` service for browser-based multiplayer.
+- [x] Wire `confirmHostGame` and `confirmJoinGame` to use the new service.
+- [x] Provide redirect from profile page when user is not signed in.
+- [x] Document updated architecture after changes.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -24,7 +24,13 @@ export default function ProfilePage() {
   }, []);
 
   if (!auth.isAuthenticated()) {
-    return <p className="p-4">Please sign in first.</p>;
+    useEffect(() => {
+      const id = setTimeout(() => {
+        window.location.href = '/';
+      }, 3000);
+      return () => clearTimeout(id);
+    }, []);
+    return <p className="p-4">Please sign in first. Returning you to game...</p>;
   }
 
   const save = () => {

--- a/src/components/GoogleGeminiInteractiveBoard.tsx
+++ b/src/components/GoogleGeminiInteractiveBoard.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast"; // Assuming this hook exists
 import { Feedback, initAudio } from "@/lib/sound"; // Assuming sound feedback functions exist
 import SoundSettings from "@/components/SoundSettings"; // Assuming this component exists
+import LocalMultiplayer from '@/services/LocalMultiplayer';
 import {
   GameState,
   GameStatus,
@@ -451,21 +452,19 @@ const InteractiveBoard: React.FC = () => {
   };
 
   const confirmJoinGame = (codeToJoin: string) => {
-    // TODO: Implement actual Jami/multiplayer connection logic here
     console.log(`Attempting to join game with code: ${codeToJoin}`);
     Feedback.buttonClick();
+    LocalMultiplayer.joinGame(codeToJoin);
     toast({ title: "Joining Game...", description: `Connecting with code ${codeToJoin}...`, duration: 3000 });
-    // Close dialog after attempting connection (or on success)
     setShowJoinGameDialog(false);
-    setGameCode(''); // Clear input after use
+    setGameCode('');
   };
 
   const confirmHostGame = () => {
-    // TODO: Implement actual Jami/multiplayer hosting logic here
     console.log(`Attempting to host game with code: ${generatedGameCode}`);
     Feedback.buttonClick();
+    LocalMultiplayer.hostGame(generatedGameCode);
     toast({ title: "Hosting Game...", description: `Waiting for opponent with code ${generatedGameCode}...`, duration: 3000 });
-    // Close dialog after starting host process
     setShowHostGameDialog(false);
   };
 

--- a/src/services/LocalMultiplayer.ts
+++ b/src/services/LocalMultiplayer.ts
@@ -1,0 +1,50 @@
+export type LocalGameMessage =
+  | { type: 'join-request' }
+  | { type: 'join-accepted' }
+  | { type: 'custom'; payload: any };
+
+class LocalMultiplayer {
+  private channel: BroadcastChannel | null = null;
+  private listeners = new Set<(msg: LocalGameMessage) => void>();
+
+  hostGame(code: string) {
+    this.close();
+    this.channel = new BroadcastChannel(`xiangqi-${code}`);
+    this.channel.onmessage = (e) => {
+      const msg = e.data as LocalGameMessage;
+      if (msg.type === 'join-request') {
+        this.channel?.postMessage({ type: 'join-accepted' });
+      }
+      this.listeners.forEach((fn) => fn(msg));
+    };
+  }
+
+  joinGame(code: string) {
+    this.close();
+    this.channel = new BroadcastChannel(`xiangqi-${code}`);
+    this.channel.onmessage = (e) => {
+      const msg = e.data as LocalGameMessage;
+      this.listeners.forEach((fn) => fn(msg));
+    };
+    this.channel.postMessage({ type: 'join-request' });
+  }
+
+  send(msg: LocalGameMessage) {
+    this.channel?.postMessage(msg);
+  }
+
+  on(fn: (msg: LocalGameMessage) => void) {
+    this.listeners.add(fn);
+  }
+
+  off(fn: (msg: LocalGameMessage) => void) {
+    this.listeners.delete(fn);
+  }
+
+  close() {
+    this.channel?.close();
+    this.channel = null;
+  }
+}
+
+export default new LocalMultiplayer();


### PR DESCRIPTION
## Summary
- snapshot architecture before host/join update
- create LocalMultiplayer service with BroadcastChannel
- hook host/join dialogs up to LocalMultiplayer
- redirect unauthenticated profile visitors back to the game
- document updated architecture and add checklist

## Testing
- `npm test` *(fails: Test Suites: 3 failed, 2 passed, 5 total)*
- `npm run lint` *(interactive prompt triggered)*

------
https://chatgpt.com/codex/tasks/task_e_68653c062d1083238f94d3d16d94c450